### PR TITLE
Omit protocol from resources to fix https

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 
     <title>FakeItEasy - It's faking amazing</title>
 
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.2.1/pure-min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.2.1/pure-min.css">
     <link rel="stylesheet" href="css/fakeiteasy.css">
     <link rel="stylesheet" href="css/syntax.css">
-    <link href="http://fonts.googleapis.com/css?family=Ubuntu:400,700" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Ubuntu:400,700" rel="stylesheet" type="text/css">
     
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
@@ -99,7 +99,7 @@ A.CallTo(() => shop.BuyCandy(lollipop)).MustHaveHappened();
     </div>
     
     <div class="footer">
-      <div style="background: #00578e url('http://www.jetbrains.com/img/banners/Codebetter.png') no-repeat 0 50%; margin:auto;padding:0;text-decoration:none;text-indent:0;letter-spacing:-0.001em; width:728px; height:90px">
+      <div style="background: #00578e url('//www.jetbrains.com/img/banners/Codebetter.png') no-repeat 0 50%; margin:auto;padding:0;text-decoration:none;text-indent:0;letter-spacing:-0.001em; width:728px; height:90px">
         <a href="http://www.jetbrains.com/youtrack" title="YouTrack by JetBrains" style="margin: 60px 0 0 190px;padding: 0; float: left;font-size: 14px; background-image:none;border:0;color: #acc4f9; font-family: trebuchet ms,arial,sans-serif;font-weight: normal;text-align:left;">keyboard-centric bug tracker</a>
         <a href="http://www.jetbrains.com/teamcity" title="TeamCity by JetBrains" style="margin:0 0 0 400px;padding:60px 0 2px 0;font-size:14px; background-image:none;border:0;display:block; color: #acc4f9; font-family: trebuchet ms,arial,sans-serif;font-weight: normal;text-align:left;">continuous integration server</a>
       </div>


### PR DESCRIPTION
Fixes the mixed content errors and loads fonts/css/images when
accessing https://fakeiteasy.github.io/
Note the change from Yahoo CDN to CloudFlare CDN, as yui.yahooapis.com
doesn't support https.