### PR TITLE
Fix links pointing to readthedocs

### DIFF
--- a/docs/analyzers/6.1/index.html
+++ b/docs/analyzers/6.1/index.html
@@ -353,19 +353,19 @@ NuGet packages in each project that needs it:</p>
 <td>FakeItEasy0003</td>
 <td>Argument constraint outside call spec</td>
 <td>no</td>
-<td>Triggered when you try to use an <a href="https://fakeiteasy.readthedocs.io/en/latest/argument-constraints/">argument constraint</a> outside of a <a href="https://fakeiteasy.readthedocs.io/en/latest/specifying-a-call-to-configure/">call specification</a>.</td>
+<td>Triggered when you try to use an <a href="https://fakeiteasy.github.io/docs/stable/argument-constraints/">argument constraint</a> outside of a <a href="https://fakeiteasy.github.io/docs/stable/specifying-a-call-to-configure/">call specification</a>.</td>
 </tr>
 <tr>
 <td>FakeItEasy0004</td>
 <td>Argument constraint nullability mismatch</td>
 <td>yes</td>
-<td>Triggered when you use a non-nullable <a href="https://fakeiteasy.readthedocs.io/en/latest/argument-constraints/">argument constraint</a> for a nullable parameter. Calls where the argument is null won't be matched. If this is intentional, consider using <code>A&lt;T?&gt;.That.IsNotNull()</code> instead. If it's not, make the argument constraint nullable (<code>A&lt;T?&gt;</code>).</td>
+<td>Triggered when you use a non-nullable <a href="https://fakeiteasy.github.io/docs/stable/argument-constraints/">argument constraint</a> for a nullable parameter. Calls where the argument is null won't be matched. If this is intentional, consider using <code>A&lt;T?&gt;.That.IsNotNull()</code> instead. If it's not, make the argument constraint nullable (<code>A&lt;T?&gt;</code>).</td>
 </tr>
 <tr>
 <td>FakeItEasy0005</td>
 <td>Argument constraint type mismatch</td>
 <td>yes</td>
-<td>Triggered when you use an <a href="https://fakeiteasy.readthedocs.io/en/latest/argument-constraints/">argument constraint</a> whose type doesn't match the parameter. No such calls can be matched.</td>
+<td>Triggered when you use an <a href="https://fakeiteasy.github.io/docs/stable/argument-constraints/">argument constraint</a> whose type doesn't match the parameter. No such calls can be matched.</td>
 </tr>
 <tr>
 <td><del>FakeItEasy0006</del></td>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ A.CallTo(() => shop.BuyCandy(lollipop)).MustHaveHappened();</pre></code>
       </div>
 
       <div class="navigation">
-        <a id="button-quickstart" class="pure-button" href="http://fakeiteasy.readthedocs.io/en/stable/quickstart/">Quickstart</a>
+        <a id="button-quickstart" class="pure-button" href="docs/stable/quickstart/">Quickstart</a>
         <a id="button-docs" class="pure-button" href="docs/">Documentation</a>
         <a id="button-chat" class="pure-button" href="https://gitter.im/FakeItEasy/FakeItEasy">Chat</a>
         <a id="button-project" class="pure-button" href="https://github.com/FakeItEasy/FakeItEasy">Source</a>


### PR DESCRIPTION
We'll also need to fix the analyzer docs so that they don't come back (see https://github.com/FakeItEasy/FakeItEasy.Analyzers/pull/36)