### PR TITLE
Set SNIPPETS_REPO_ROOT environment to 'source' so it can be a base_path

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -71,6 +71,8 @@ jobs:
           echo "sha1=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Generate the docs
         id: generate-docs
+        env:
+          SNIPPETS_REPO_ROOT: source
         run: |
           version=${{ github.event.inputs.version }}
           aliasClause=


### PR DESCRIPTION
The second part of FakeItEasy/FakeItEasy#1918. I hope. I'm doing like no testing here.