### PR TITLE
Read workflow inputs from inputs object

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -62,11 +62,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
-      - name: Checkout ${{ github.event.inputs.source-repo }}
+      - name: Checkout ${{ inputs.source-repo }}
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.source-repo }}
-          ref: ${{ github.event.inputs.source-ref }}
+          repository: ${{ inputs.source-repo }}
+          ref: ${{ inputs.source-ref }}
           path: source
           fetch-depth: 0
       - name: Setup Python
@@ -97,24 +97,24 @@ jobs:
         env:
           SNIPPETS_REPO_ROOT: source
         run: |
-          version=${{ github.event.inputs.version }}
+          version=${{ inputs.version }}
           aliasClause=
           versionForMessage=$version
           if [ "$version" = "${{ steps.get-latest-tag.outputs.latest-tag }}" ]; then
             aliasClause="stable --update-aliases"
             versionForMessage="$versionForMessage, stable"
           fi
-          message="Generate docs from ${{ github.event.inputs.source-repo }}@${{ steps.get-source-commit.outputs.sha1 }} ($versionForMessage)"
+          message="Generate docs from ${{ inputs.source-repo }}@${{ steps.get-source-commit.outputs.sha1 }} ($versionForMessage)"
           targetBranch=update-$version-docs
           echo "docs-branch=$targetBranch" >> $GITHUB_OUTPUT
           git branch $targetBranch
           mike deploy "$version" $aliasClause \
             --branch "$targetBranch" \
-            --prefix "${{ github.event.inputs.output-prefix }}" \
+            --prefix "${{ inputs.output-prefix }}" \
             --config-file source/mkdocs.yml \
             --message "$message"
       - name: Create pull request
-        if: github.event.inputs.publish-mode == 'pull-request'
+        if: inputs.publish-mode == 'pull-request'
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
@@ -122,7 +122,7 @@ jobs:
           git push origin "$docsBranch:$docsBranch"
           gh pr create --base master --head "$docsBranch" --fill
       - name: Merge changes
-        if: github.event.inputs.publish-mode == 'auto-merge'
+        if: inputs.publish-mode == 'auto-merge'
         run: |
           git merge "${{ steps.generate-docs.outputs.docs-branch }}"
           git push


### PR DESCRIPTION
When using call_workflow, the passed values are only available on inputs, not on github.events.inputs.

https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context